### PR TITLE
Add user icinga to the sudo configuration

### DIFF
--- a/sudo-profile-check_zypper
+++ b/sudo-profile-check_zypper
@@ -1,4 +1,4 @@
-nagios ALL=(ALL) NOPASSWD: /usr/sbin/zypp-refresh "",\
+nagios,icinga ALL=(ALL) NOPASSWD: /usr/sbin/zypp-refresh "",\
                            /usr/bin/zypper refresh,\
                            /usr/bin/zypper services,\
                            /usr/bin/zypper --xmlout --non-interactive list-updates --type package --type patch


### PR DESCRIPTION
A common deployment scenario for check_zypper is to execute the check
via the icinga2 agent. The icinga2 agent runs as user "icinga" so let's
grant this user the same sudo permission as for the user "nagios".